### PR TITLE
Fix jshint warning in NumberListOperators and move function creation out of the loop.

### DIFF
--- a/src/operators/numeric/numberList/NumberListOperators.js
+++ b/src/operators/numeric/numberList/NumberListOperators.js
@@ -346,28 +346,29 @@ NumberListOperators.averageSmoother = function(numberList, intensity, nIteration
   var anti = 1 - 2 * intensity;
   var n = numberList.length - 1;
 
-  var newNumberList = new NumberList();
+  var newNumberList = numberList.clone();
   var i;
 
-  newNumberList.name = numberList.name;
+  var smoothFirst = function(val, i, list){
+    list[i] = anti * val + (i > 0 ? (numberList[i - 1] * intensity) : 0) + (i < n ? (numberList[i + 1] * intensity) : 0);
+  };
+
+  var smooth = function(val, i, list){
+    list[i] = anti * val + (i > 0 ? (list[i - 1] * intensity) : 0) + (i < n ? (list[i + 1] * intensity) : 0);
+  };
 
   for(i = 0; i < nIterations; i++) {
     if(i === 0) {
-      numberList.forEach(function(val, i) {
-        newNumberList[i] = anti * val + (i > 0 ? (numberList[i - 1] * intensity) : 0) + (i < n ? (numberList[i + 1] * intensity) : 0);
-      });
+      newNumberList.forEach(smoothFirst);
     } else {
-      newNumberList.forEach(function(val, i) {
-        newNumberList[i] = anti * val + (i > 0 ? (newNumberList[i - 1] * intensity) : 0) + (i < n ? (newNumberList[i + 1] * intensity) : 0);
-      });
-    }
+      newNumberList.forEach(smooth);
+    }    
   }
 
   newNumberList.name = numberList.name;
 
   return newNumberList;
 };
-
 
 /**
  * accepted comparison operators: "<", "<=", ">", ">=", "==", "!="

--- a/tests/NumberListOperators.test.js
+++ b/tests/NumberListOperators.test.js
@@ -51,4 +51,17 @@ describe("NumberListOperators", function() {
     expect(kTable[0][2]).toBe(1);
   });
 
+
+  it("should smooth a numberlist", function(){
+    var nl1 = new mo.NumberList(1,1,3,5,5,5,10);
+    var expected = new mo.NumberList(0.9, 1.2000000000000002, 3.0000000000000004, 4.8, 5, 5.5, 8.5);    
+    var smoothed = mo.NumberListOperators.averageSmoother(nl1);    
+    expect(expected.isEquivalent(smoothed)).toBe(true);
+
+    var nl2 = new mo.NumberList(1,1,3,5,5,5,10);
+    var expected2 = new mo.NumberList(0.7908480000000003, 1.5470480000000004, 3.023488960000001, 4.419526096, 5.056700208000001, 5.828072627040001, 5.770294455024001);
+    var smoothed2= mo.NumberListOperators.averageSmoother(nl2, 0.1, 4);    
+    expect(expected2.isEquivalent(smoothed2)).toBe(true);
+  });
+
 });


### PR DESCRIPTION
@moebio take a look at this. You can also look at the test that I added to check if i was keeping it doing the same thing. The expected values i generated just by running the function with those params before doing any modification.

Another possibility. It is possible to change this function to look like.

```javascript
NumberListOperators.averageSmoother = function(numberList, intensity, nIterations) {
  nIterations = nIterations == null ? 1 : nIterations;
  intensity = intensity == null ? 0.1 : intensity;

  intensity = Math.max(Math.min(intensity, 0.5), 0);
  var anti = 1 - 2 * intensity;
  var n = numberList.length - 1;
  var i;
  var newNumberList = numberList.clone();  
    
  var smooth = function(val, i, list){
    list[i] = anti * val + (i > 0 ? (list[i - 1] * intensity) : 0) + (i < n ? (list[i + 1] * intensity) : 0);
  };

  for(i = 0; i < nIterations; i++) {
    newNumberList.forEach(smooth);    
  }

  return newNumberList;
};
```

Note the difference here is that there is only one smooth function and no branch in the for loop. However this produces a slightly different output than my current PR. This is because as it smoothes over the array in its first iteration, the current version will use values from the original array for its entire first iteration (essentially the updates are invisible to the first iteration), the above snippet propagates changes made in the first iteration (making it like the others). So that may obviously __not__ be how it should work. But i thought i'd post it just in case.

In terms of the difference in values. here are some samples

```
1 iteration
source -> mo.NumberList(1,1,3,5,5,5,10);

result with current code (and PR code) ->  [0.9, 1.2000000000000002, 3.0000000000000004, 4.8, 5, 5.5, 8.5]
result with snippet code -> [0.8400000000000001, 1.3440000000000003, 3.0144, 4.64144, 5.014144, 5.7514144, 7.375141440000001]

4 iterations
source -> mo.NumberList(1,1,3,5,5,5,10);

result with current code (and PR code) ->  [0.7908480000000003, 1.5470480000000004, 3.023488960000001, 4.419526096, 5.056700208000001, 5.828072627040001, 5.770294455024001]

result with snippet code -> [0.7920000000000003, 1.5518000000000005, 2.9971000000000005, 4.418200000000001, 5.0857, 5.8222000000000005, 5.747800000000002]
```

Again I wouldn't be surprised if the snippet code results are just wrong.

