### PR TITLE
Improve categorical colors

### DIFF
--- a/src/operators/graphic/ColorListGenerators.js
+++ b/src/operators/graphic/ColorListGenerators.js
@@ -7,9 +7,14 @@ import Table from "src/dataTypes/lists/Table";
 import List from "src/dataTypes/lists/List";
 import NumberListOperators from "src/operators/numeric/numberList/NumberListOperators";
 
+// ColorListGenerators._HARDCODED_CATEGORICAL_COLORS = new ColorList(
+//   "#dd4411", "#2200bb", "#1f77b4", "#ff660e", "#2ca02c", "#d62728", "#9467bd", "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf", "#dd8811",
+//   "#dd0011", "#221140", "#1f66a3", "#ff220e", "#2ba01c", "#442728", "#945600", "#8c453a", "#e37700"
+// );
+
 ColorListGenerators._HARDCODED_CATEGORICAL_COLORS = new ColorList(
-  "#dd4411", "#2200bb", "#1f77b4", "#ff660e", "#2ca02c", "#d62728", "#9467bd", "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf", "#dd8811",
-  "#dd0011", "#221140", "#1f66a3", "#ff220e", "#2ba01c", "#442728", "#945600", "#8c453a", "#e37700"
+  "#e03030", "#1f7ab8", "#10bb20", "#ffe500", "#9467bd", "#ff7700", "#2232ff", "#206010", "#e388d2", "#a66020",
+  "#ff5555", "#17becc", "#20df33", "#dfc500", "#ccaaff", "#ffaa44", "#66bbff", "#a5ffa5", "#ffbbdd", "#ddc277"
 );
 
 /**
@@ -155,6 +160,9 @@ ColorListGenerators.createCategoricalColors = function(mode, nColors, colorScale
       for(i = 0; i < nColors; i++) {
         newColorList[i] = colorList[i%colorList.length];
       }
+      break;
+    case 3:
+      newColorList = ColorListGenerators.createColorListSpectrum(nColors);
       break;
     case 4:
     case 5:

--- a/src/operators/graphic/ColorListGenerators.js
+++ b/src/operators/graphic/ColorListGenerators.js
@@ -122,7 +122,7 @@ ColorListGenerators.createColorListSpectrum = function(nColors, saturation,value
 
 /**
  * Creates a ColorList of categorical colors
- * @param {Number} mode 0:simple picking from color scale function, 1:random (with seed), 2:hardcoded colors, 3:, 4:, 5:evolutionary algorithm, guarantees non consecutive similar colors
+ * @param {Number} mode 0:simple picking from color scale function, 1:random (with seed), 2:hardcoded colors, 3:spectrum colors, 4:evolutionary algorithm, guarantees non consecutive similar colors(spectrum), 5:evolutionary algorithm, guarantees non consecutive similar colors(colorScale)
  * @param {Number} nColors
  *
  * @param {ColorScale} colorScaleFunction

--- a/src/operators/graphic/ColorListGenerators.js
+++ b/src/operators/graphic/ColorListGenerators.js
@@ -166,7 +166,8 @@ ColorListGenerators.createCategoricalColors = function(mode, nColors, colorScale
       var nGenerations = Math.floor(nColors * 2) + 100;
       var nChildren = Math.floor(nColors * 0.6) + 5;
       var bCircular = mode == 4;
-      var bestEvaluation = ColorListGenerators._evaluationFunction(randomPositions,bCircular);
+      var bExtendedNeighbourhood = mode == 4;
+      var bestEvaluation = ColorListGenerators._evaluationFunction(randomPositions,bCircular,bExtendedNeighbourhood);
       var child;
       var bestChildren = randomPositions;
       var j;
@@ -177,7 +178,7 @@ ColorListGenerators.createCategoricalColors = function(mode, nColors, colorScale
         for(j = 0; j < nChildren; j++) {
           child = ColorListGenerators._sortingVariation(randomPositions, randomNumbersSource[nr], randomNumbersSource[nr + 1]);
           nr = (nr + 2) % 1001;
-          evaluation = ColorListGenerators._evaluationFunction(child,bCircular,bCircular);
+          evaluation = ColorListGenerators._evaluationFunction(child,bCircular,bExtendedNeighbourhood);
           if(evaluation > bestEvaluation) {
             bestChildren = child;
             bestEvaluation = evaluation;
@@ -226,18 +227,23 @@ ColorListGenerators._sortingVariation = function(numberList, rnd0, rnd1) { //pri
 /**
  * @ignore
  */
-ColorListGenerators._evaluationFunction = function(numberList, bCircular) { //private
+ColorListGenerators._evaluationFunction = function(numberList, bCircular, bExtendedNeighbourhood) { //private
   // bCircular == true means distance between 0 and n-1 is 1
+  // bExtendedNeighbourhood == true means consider diffs beyond adjacent pairs
   var sum = 0;
-  var i,d,
+  var i,d,r2,
     len=numberList.length,
     h=Math.floor(len/2);
-  for(i = 0; numberList[i + 1] != null; i++) {
-    d = Math.abs(numberList[i + 1] - numberList[i]);
-    if(bCircular && d > h){
-      d = len-d;
+  var range = bExtendedNeighbourhood ? 4 : 1;
+  for(var r=1; r <= range; r++){
+    r2 = r*r;
+    for(i = 0; numberList[i + r] != null; i++) {
+      d = Math.abs(numberList[i + r] - numberList[i]);
+      if(bCircular && d > h){
+        d = len-d;
+      }
+      sum += Math.sqrt(d/r2);
     }
-    sum += Math.sqrt(d);
   }
   return sum;
 };

--- a/src/operators/graphic/ColorListGenerators.js
+++ b/src/operators/graphic/ColorListGenerators.js
@@ -8,8 +8,8 @@ import List from "src/dataTypes/lists/List";
 import NumberListOperators from "src/operators/numeric/numberList/NumberListOperators";
 
 ColorListGenerators._HARDCODED_CATEGORICAL_COLORS = new ColorList(
-  "#e03030", "#1f7ab8", "#10bb20", "#ffe500", "#9467bd", "#ff7700", "#2232ff", "#206010", "#e388d2", "#a66020",
-  "#ff5555", "#17becc", "#20df33", "#dfc500", "#ccaaff", "#ffaa44", "#66bbff", "#a5ffa5", "#ffbbdd", "#ddc277"
+  "#d62728", "#1f77b4", "#2ca02c", "#ff7f00", "#9467bd", "#bcbd22", "#8c564b", "#17becf", "#dd4411", "#206010", "#e377c2",
+  "#2200bb", "#dd8811", "#ff220e", "#1f66a3", "#8c453a", "#2ba01c", "#dfc500", "#945600", "#ff008b", "#e37700", "#7f7f7f"
 );
 
 /**

--- a/src/operators/graphic/ColorListGenerators.js
+++ b/src/operators/graphic/ColorListGenerators.js
@@ -7,11 +7,6 @@ import Table from "src/dataTypes/lists/Table";
 import List from "src/dataTypes/lists/List";
 import NumberListOperators from "src/operators/numeric/numberList/NumberListOperators";
 
-// ColorListGenerators._HARDCODED_CATEGORICAL_COLORS = new ColorList(
-//   "#dd4411", "#2200bb", "#1f77b4", "#ff660e", "#2ca02c", "#d62728", "#9467bd", "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf", "#dd8811",
-//   "#dd0011", "#221140", "#1f66a3", "#ff220e", "#2ba01c", "#442728", "#945600", "#8c453a", "#e37700"
-// );
-
 ColorListGenerators._HARDCODED_CATEGORICAL_COLORS = new ColorList(
   "#e03030", "#1f7ab8", "#10bb20", "#ffe500", "#9467bd", "#ff7700", "#2232ff", "#206010", "#e388d2", "#a66020",
   "#ff5555", "#17becc", "#20df33", "#dfc500", "#ccaaff", "#ffaa44", "#66bbff", "#a5ffa5", "#ffbbdd", "#ddc277"
@@ -37,7 +32,7 @@ export default ColorListGenerators;
  */
 ColorListGenerators.createDefaultCategoricalColorList = function(nColors, alpha, invert) {
   alpha = alpha == null ? 1 : alpha;
-  var colors = ColorListGenerators.createCategoricalColors(1, nColors).getInterpolated('black', 0.15);
+  var colors = ColorListGenerators.createCategoricalColors(2, nColors);
   if(alpha < 1) colors = colors.addAlpha(alpha);
 
   if(invert) colors = colors.getInverted();
@@ -157,8 +152,16 @@ ColorListGenerators.createCategoricalColors = function(mode, nColors, colorScale
       break;
     case 2:
       colorList = colorList==null?ColorListGenerators._HARDCODED_CATEGORICAL_COLORS:colorList;
+      var nInterpolate;
       for(i = 0; i < nColors; i++) {
         newColorList[i] = colorList[i%colorList.length];
+        if(i >= colorList.length){
+          // move towards black
+          nInterpolate = Math.floor(i/colorList.length);
+          for(var j=0; j < nInterpolate;j++){
+            newColorList[i]= ColorOperators.interpolateColors(newColorList[i],'black',0.20);
+          }
+        }
       }
       break;
     case 3:

--- a/src/operators/graphic/ColorListGenerators.js
+++ b/src/operators/graphic/ColorListGenerators.js
@@ -2,6 +2,7 @@ import ColorList from "src/dataTypes/graphic/ColorList";
 import ColorScales from "src/operators/graphic/ColorScales";
 import NumberListGenerators from "src/operators/numeric/numberList/NumberListGenerators";
 import ListOperators from "src/operators/lists/ListOperators";
+import ColorOperators from "src/operators/graphic/ColorOperators";
 import Table from "src/dataTypes/lists/Table";
 import List from "src/dataTypes/lists/List";
 import NumberListOperators from "src/operators/numeric/numberList/NumberListOperators";
@@ -88,6 +89,32 @@ ColorListGenerators.createColorListWithSingleColor = function(nColors, color) {
   var colorList = new ColorList();
   for(var i = 0; i < nColors; i++) {
     colorList.push(color);
+  }
+  return colorList;
+};
+
+
+/**
+ * Creates a new ColorList from the full spectrum. Size of the List
+ * is controlled by the nColors input.
+ *
+ * @param {Number} nColors Length of the list (default 8).
+ * @param {Number} saturation in range [0,1]
+ * @param {Number} value in range [0,1]
+ * @return {ColorList} ColorList with spectrum colors
+ * tags:generator
+*/
+ColorListGenerators.createColorListSpectrum = function(nColors, saturation,value) {
+  // use HSV and rotate through hues
+  nColors = nColors == null? 8:nColors;
+  saturation = saturation == null? 1:saturation;
+  value = value == null? 1:value;
+  var colorList = new ColorList();
+  var hue;
+  for(var i = 0; i < nColors; i++) {
+    // hue of 0 == hue of 360 so we go to nColors-1
+    hue = 360*i/nColors;
+    colorList.push(ColorOperators.HSVtoHEX(hue,saturation,value));
   }
   return colorList;
 };
@@ -274,7 +301,7 @@ ColorListGenerators.createCategoricalColorListForList = function(list, colorList
   var fullColorList = ListOperators.translateWithDictionary(list, colorDictTable, 'black');
 
   fullColorList = ColorList.fromArray(fullColorList);
-  
+
   return [
     {
       value: fullColorList,


### PR DESCRIPTION
To address issue #201 raised by @moebio.

Inside ColorListGenerators the method createDefaultCategoricalColorList uses createCategoricalColors to construct the list. It used to take a pseudorandom(but deterministic) sample of nColors from ColorScales.temperature. The result (labeled Old below) had lots of greenish hues and some very dark colors.
![screen shot 2015-09-16 at 10 05 42 am](https://cloud.githubusercontent.com/assets/1721620/9907465/4a19c93c-5c5d-11e5-817e-0fce14577951.png)

It is very difficult to algorithmically generate pleasing palettes of many distinct colors. I tried an approach using the full spectrum and some enhancements to the evolutionary algorithm. This option is available with mode 4 in createCategoricalColors but I wasn't happy with the results.

Instead I chose to use a fixed palette. Our existing hardcoded palette isn't bad but of the first 4 colors 2 are shades of orange and 2 shades of blue.
![screen shot 2015-09-15 at 8 23 22 pm](https://cloud.githubusercontent.com/assets/1721620/9907638/2101936c-5c5e-11e5-9d3e-88d56a6dc9df.png)

I hand-constructed a new palette for our hardcoded colors and use it in the createDefaultCategoricalColorList method. It has 20 colors and the code uses darker versions of the colors if more than 20 are required.
![screen shot 2015-09-16 at 10 16 52 am](https://cloud.githubusercontent.com/assets/1721620/9907756/8f1932d8-5c5e-11e5-91c7-f6195e7cf04d.png)

- The project http://lichen-stg.moebio.com/modular_platform/LICHEN/#/jeff/colorListShow might be useful for testing (saved locally so it uses appropriate code)