### PR TITLE
Speed up sort operations on lists with lots of repeated items

### DIFF
--- a/src/dataTypes/lists/List.js
+++ b/src/dataTypes/lists/List.js
@@ -936,11 +936,11 @@ List.prototype.getSortedByList = function(list, ascending) {
   var comparator;
   if(ascending) {
     comparator = function(a, b) {
-      return a[1] < b[1] ? -1 : 1;
+      return a[1] < b[1] ? -1 : a[1] > b[1] ?  1 : 0;
     };
   } else {
     comparator = function(a, b) {
-      return a[1] < b[1] ? 1 : -1;
+      return a[1] < b[1] ?  1 : a[1] > b[1] ? -1 : 0;
     };
   }
 

--- a/src/operators/lists/ListOperators.js
+++ b/src/operators/lists/ListOperators.js
@@ -473,13 +473,11 @@ ListOperators.sortListByNumberList = function(list, numberList, descending) {
 
   if(descending) {
     pairs.sort(function(a, b) {
-      if(a[1] < b[1]) return 1;
-      return -1;
+      return a[1] < b[1] ?  1 : a[1] > b[1] ? -1 : 0;
     });
   } else {
     pairs.sort(function(a, b) {
-      if(a[1] < b[1]) return -1;
-      return 1;
+      return a[1] < b[1] ? -1 : a[1] > b[1] ?  1 : 0;
     });
   }
 


### PR DESCRIPTION
Our main list sort operations were using comparators that did not return 0 in the case of equal items.
The effect was that sorts on lists with lots of repeated items were much slower than necessary.

For example, a list of 10,000 items where each is one of 4 strings is now about 150 times faster.
A list of 100,000 items where each is one of 4 strings is now about 500 times faster.

speeds on lists with non-repeating items is roughly the same as before.