### PR TITLE
Sort stability

### DIFF
--- a/src/dataTypes/lists/List.js
+++ b/src/dataTypes/lists/List.js
@@ -930,17 +930,17 @@ List.prototype.getSortedByList = function(list, ascending) {
   var l = this.length;
 
   for(i = 0; i<l; i++) {
-    pairsArray[i] = [this[i], list[i]];
+    pairsArray[i] = [this[i], list[i],i];
   }
 
   var comparator;
   if(ascending) {
     comparator = function(a, b) {
-      return a[1] < b[1] ? -1 : a[1] > b[1] ?  1 : 0;
+      return a[1] < b[1] ? -1 : a[1] > b[1] ?  1 : a[2] - b[2];
     };
   } else {
     comparator = function(a, b) {
-      return a[1] < b[1] ?  1 : a[1] > b[1] ? -1 : 0;
+      return a[1] < b[1] ?  1 : a[1] > b[1] ? -1 : a[2] - b[2];
     };
   }
 

--- a/src/operators/lists/ListOperators.js
+++ b/src/operators/lists/ListOperators.js
@@ -467,17 +467,17 @@ ListOperators.sortListByNumberList = function(list, numberList, descending) {
   var i;
 
   for(i = 0; list[i] != null; i++) {
-    pairs.push([list[i], numberList[i]]);
+    pairs.push([list[i], numberList[i],i]);
   }
 
 
   if(descending) {
     pairs.sort(function(a, b) {
-      return a[1] < b[1] ?  1 : a[1] > b[1] ? -1 : 0;
+      return a[1] < b[1] ?  1 : a[1] > b[1] ? -1 : a[2] - b[2];
     });
   } else {
     pairs.sort(function(a, b) {
-      return a[1] < b[1] ? -1 : a[1] > b[1] ?  1 : 0;
+      return a[1] < b[1] ? -1 : a[1] > b[1] ?  1 : a[2] - b[2];
     });
   }
 


### PR DESCRIPTION
When sorting one list by another or a whole Table by a list it's often important to preserve the original order for equal values of the sort list items. The sort operation in Chrome and some other browsers does not have this property.

This change adds stability to ListOperators.sortListByNumberList which also fixes TableOperators.sortListsByNumberList . There is a small performance penalty when sorting lists with mostly repeating values. My test case of 1 million items where the sort list had the same 4 values repeated was about 15% slower - a 300ms difference. For typical sorting where there are few repeating values the difference is negligible.

Also made the change to List.prototype.getSortedByList
