### PR TITLE
Add NetworkOperators for calculating centrality measures

### DIFF
--- a/src/operators/structures/NetworkOperators.js
+++ b/src/operators/structures/NetworkOperators.js
@@ -1490,7 +1490,7 @@ NetworkOperators._jLouvain = function() {
   return core;
 };
 
-NetworkOperators.getAdjacencyMap = function(network,bDirected,bReversed,bStochastic){
+NetworkOperators._getAdjacencyMap = function(network,bDirected,bReversed,bStochastic){
 // derived from Graph.js inside http://www.clips.ua.ac.be/pages/pattern
   if(network==null) return null;
   bDirected = bDirected == null ? false : bDirected;
@@ -1556,7 +1556,7 @@ NetworkOperators.addEigenvectorCentralityToNodes = function(network, bNormalized
       vector[node] *= w;
     }
   }
-  var G = NetworkOperators.getAdjacencyMap(network,null,bReversed);
+  var G = NetworkOperators._getAdjacencyMap(network,null,bReversed);
   NumberOperators.randomSeed(1); // use consistent random function so we get consistent results
   var v = {}; for(var i=0;i<network.nodeList.length;i++) v[network.nodeList[i].id] = NumberOperators.random(); normalize(v);
   NumberOperators.randomSeedPop();
@@ -1642,7 +1642,7 @@ NetworkOperators.addBetweennessCentralityToNodes = function(network, bNormalized
       };
   };
 
-  var W = NetworkOperators.getAdjacencyMap(network,null,true);
+  var W = NetworkOperators._getAdjacencyMap(network,null,true);
   var b = {}; for(var i=0;i<network.nodeList.length;i++) b[network.nodeList[i].id] = 0.0;
   var dist,pred,v;
   for(i=0;i<network.nodeList.length;i++) {

--- a/src/operators/structures/NetworkOperators.js
+++ b/src/operators/structures/NetworkOperators.js
@@ -1529,6 +1529,7 @@ NetworkOperators.getAdjacencyMap = function(network,bDirected,bReversed,bStochas
  * @param {Network} network
  * @param {Boolean} bNormalized=true (default), scale so maximum eigenvectorCentrality is 1
  * @param {Boolean} bReversed=true (default), use outgoing relations
+ * @return {Network}
  * tags:analytics,transformative
  */
 NetworkOperators.addEigenvectorCentralityToNodes = function(network, bNormalized, bReversed) {
@@ -1542,7 +1543,7 @@ NetworkOperators.addEigenvectorCentralityToNodes = function(network, bNormalized
   // Based on: NetworkX, Aric Hagberg (hagberg@lanl.gov)
   // http://python-networkx.sourcearchive.com/documentation/1.0.1/centrality_8py-source.html
   // Note: much faster than betweenness centrality (which grows exponentially).
-  if(network == null) return;
+  if(network == null) return network;
   if(bNormalized === undefined) bNormalized = true;
   if(bReversed   === undefined) bReversed   = true;
   var nIterations = 100;
@@ -1583,13 +1584,14 @@ NetworkOperators.addEigenvectorCentralityToNodes = function(network, bNormalized
         var node = network.nodeList.getNodeById(id);
         node.eigenvectorCentrality = v[id];
       }
-      return;
+      return network;
     }
   }
   // node weight is 0 because eigenvectorCentrality() did not converge
   for(var i=0;i<network.nodeList.length;i++){
     network.nodeList[i].eigenvectorCentrality=0;
   }
+  return network;
 };
 
 /**
@@ -1599,6 +1601,7 @@ NetworkOperators.addEigenvectorCentralityToNodes = function(network, bNormalized
  * @param {Network} network
  * @param {Boolean} bNormalized=true (default), scale so maximum betweennessCentrality is 1
  * @param {Boolean} bDirected=false (default), count relations in both directions
+ * @return {Network}
  * tags:analytics,transformative
  */
 NetworkOperators.addBetweennessCentralityToNodes = function(network, bNormalized, bDirected) {
@@ -1613,31 +1616,32 @@ NetworkOperators.addBetweennessCentralityToNodes = function(network, bNormalized
   // Based on: Dijkstra's algorithm for shortest paths modified from Eppstein.
   // Based on: NetworkX 1.0.1: Aric Hagberg, Dan Schult and Pieter Swart.
   // http://python-networkx.sourcearchive.com/documentation/1.0.1/centrality_8py-source.html
-  if(network == null) return;
+  if(network == null) return network;
   if(bNormalized === undefined) bNormalized = true;
   if(bDirected === undefined) bDirected = false;
 
-  var Heap = Class.extend({
-      init: function() {
-          /* Items in the heap are ordered by weight (i.e. priority).
-           * Heap.pop() returns the item with the lowest weight.
-           */
-          this.k = [];
-          this.w = [];
-          this.length = 0;
-      },
-      push: function (key, weight) {
-          var i = 0; while (i <= this.w.length && weight < (this.w[i]||Infinity)) i++;
-          this.k.splice(i, 0, key);
-          this.w.splice(i, 0, weight);
-          this.length += 1;
-          return true;            
-      },
-      pop: function () {
-          this.length -= 1;
-          this.w.pop(); return this.k.pop();
-      }
-  });
+  var Heap = function(){
+      this.init = function() {
+        /* Items in the heap are ordered by weight (i.e. priority).
+         * Heap.pop() returns the item with the lowest weight.
+         */
+        this.k = [];
+        this.w = [];
+        this.length = 0;
+      };
+      this.init();
+      this.push = function(key, weight) {
+        var i = 0; while (i <= this.w.length && weight < (this.w[i]||Infinity)) i++;
+        this.k.splice(i, 0, key);
+        this.w.splice(i, 0, weight);
+        this.length += 1;
+        return true;            
+      };
+      this.pop = function () {
+        this.length -= 1;
+        this.w.pop(); return this.k.pop();
+      };
+  };
 
   var W = NetworkOperators.getAdjacencyMap(network,null,true);
   var b = {}; for(var i=0;i<network.nodeList.length;i++) b[network.nodeList[i].id] = 0.0;
@@ -1696,6 +1700,7 @@ NetworkOperators.addBetweennessCentralityToNodes = function(network, bNormalized
     var node = network.nodeList.getNodeById(id);
     node.betweennessCentrality = b[id];
   }
+  return network;
 };
 
 /**

--- a/src/operators/structures/NetworkOperators.js
+++ b/src/operators/structures/NetworkOperators.js
@@ -1522,7 +1522,16 @@ NetworkOperators.getAdjacencyMap = function(network,bDirected,bReversed,bStochas
   return map;
 }
 
-NetworkOperators.addEigenvectorCentralityToNodes = function(network, bNormalized, bReversed, nIterations, fTolerance) {
+/**
+ * Adds eigenvectorCentrality as a property to the network nodes.
+ * Nodes with no incoming connections have a score of zero.
+ *
+ * @param {Network} network
+ * @param {Boolean} bNormalized=true (default), scale so maximum eigenvectorCentrality is 1
+ * @param {Boolean} bReversed=true (default), use outgoing relations
+ * tags:analytics,transformative
+ */
+NetworkOperators.addEigenvectorCentralityToNodes = function(network, bNormalized, bReversed) {
   // derived from Graph.js inside http://www.clips.ua.ac.be/pages/pattern
   /* Eigenvector centrality for nodes in the graph (cfr. Google's PageRank).
    * Eigenvector centrality is a measure of the importance of a node in a directed network. 
@@ -1536,8 +1545,8 @@ NetworkOperators.addEigenvectorCentralityToNodes = function(network, bNormalized
   if(network == null) return;
   if(bNormalized === undefined) bNormalized = true;
   if(bReversed   === undefined) bReversed   = true;
-  if(nIterations === undefined) nIterations = 100;
-  if(fTolerance  === undefined) fTolerance  = 0.0001;
+  var nIterations = 100;
+  var fTolerance  = 0.0001;
   var rating = {};
   function normalize(vector) {
     var v = []; for(var k in vector) v.push(vector[k]);
@@ -1580,6 +1589,112 @@ NetworkOperators.addEigenvectorCentralityToNodes = function(network, bNormalized
   // node weight is 0 because eigenvectorCentrality() did not converge
   for(var i=0;i<network.nodeList.length;i++){
     network.nodeList[i].eigenvectorCentrality=0;
+  }
+};
+
+/**
+ * Adds betweennessCentrality as a property to the network nodes.
+ * Nodes in high-density areas will get a good score.
+ *
+ * @param {Network} network
+ * @param {Boolean} bNormalized=true (default), scale so maximum betweennessCentrality is 1
+ * @param {Boolean} bDirected=false (default), count relations in both directions
+ * tags:analytics,transformative
+ */
+NetworkOperators.addBetweennessCentralityToNodes = function(network, bNormalized, bDirected) {
+  // derived from Graph.js inside http://www.clips.ua.ac.be/pages/pattern
+  /* Betweenness centrality for nodes in the graph.
+   * Betweenness centrality is a measure of the number of shortests paths that pass through a node.
+   * Nodes in high-density areas will get a good score.
+   */
+  // Ulrik Brandes, A Faster Algorithm for Betweenness Centrality,
+  // Journal of Mathematical Sociology 25(2):163-177, 2001,
+  // http://www.inf.uni-konstanz.de/algo/publications/b-fabc-01.pdf
+  // Based on: Dijkstra's algorithm for shortest paths modified from Eppstein.
+  // Based on: NetworkX 1.0.1: Aric Hagberg, Dan Schult and Pieter Swart.
+  // http://python-networkx.sourcearchive.com/documentation/1.0.1/centrality_8py-source.html
+  if(network == null) return;
+  if(bNormalized === undefined) bNormalized = true;
+  if(bDirected === undefined) bDirected = false;
+
+  var Heap = Class.extend({
+      init: function() {
+          /* Items in the heap are ordered by weight (i.e. priority).
+           * Heap.pop() returns the item with the lowest weight.
+           */
+          this.k = [];
+          this.w = [];
+          this.length = 0;
+      },
+      push: function (key, weight) {
+          var i = 0; while (i <= this.w.length && weight < (this.w[i]||Infinity)) i++;
+          this.k.splice(i, 0, key);
+          this.w.splice(i, 0, weight);
+          this.length += 1;
+          return true;            
+      },
+      pop: function () {
+          this.length -= 1;
+          this.w.pop(); return this.k.pop();
+      }
+  });
+
+  var W = NetworkOperators.getAdjacencyMap(network,null,true);
+  var b = {}; for(var i=0;i<network.nodeList.length;i++) b[network.nodeList[i].id] = 0.0;
+  var dist,pred,v;
+  for(i=0;i<network.nodeList.length;i++) {
+    var id = network.nodeList[i].id;
+    var Q = new Heap(); // Use Q as a heap with [distance, node id] lists.
+    var D = {}; // Dictionary of final distances.
+    var P = {}; // # Dictionary of paths.
+    for(var j=0;j<network.nodeList.length;j++) P[network.nodeList[j].id]=[];
+    var seen = {id: 0};
+    Q.push([0, id, id], 0);
+    var S = [];
+    var E = {};
+    for(var j=0;j<network.nodeList.length;j++) E[network.nodeList[j].id]=0; // sigma
+    E[id] = 1.0;
+    while(Q.length) {
+      var q = Q.pop(); dist=q[0]; pred=q[1]; v=q[2];
+      if(v in D) continue;
+      D[v] = dist;
+      S.push(v);
+      E[v] += E[pred];
+      for (var w in W[v]) {
+        var vw_dist = D[v] + W[v][w];
+        if(!(w in D) && (!(w in seen) || vw_dist < seen[w])) {
+          seen[w] = vw_dist;
+          Q.push([vw_dist, v, w], vw_dist);
+          P[w] = [v];
+          E[w] = 0.0;
+        } else if (vw_dist == seen[w]) { // Handle equal paths.
+          P[w].push(v);
+          E[w] = E[w] + E[v];
+        }
+      }
+    }
+    var d = {}; for(var j=0;j<network.nodeList.length;j++) d[network.nodeList[j].id]=0;
+    while (S.length) {
+      var w = S.pop();
+      for (var j=0; j < P[w].length; j++) {
+        v = P[w][j];
+        d[v] += (1 + d[w]) * E[v] / E[w];
+      }
+      if (w != id) {
+        b[w] += d[w];
+      }
+    }
+  }
+  // Normalize between 0 and 1.
+  if(bNormalized){
+    var vals = []; for(var k in b) vals.push(b[k]);
+    var m=Math.max.apply(Math, vals) || 1;
+    for(var id in b) b[id] /= m;
+  }
+  // set property on nodes
+  for(var id in b){
+    var node = network.nodeList.getNodeById(id);
+    node.betweennessCentrality = b[id];
   }
 };
 

--- a/src/operators/structures/NetworkOperators.js
+++ b/src/operators/structures/NetworkOperators.js
@@ -1510,14 +1510,13 @@ NetworkOperators.getAdjacencyMap = function(network,bDirected,bReversed,bStochas
       }
   }
   if(bStochastic) {
-      for (var id1 in map) {
-          // var n = sum(values(map[id1]));
-          var nListVals = List.fromArray(map[id1]).getImproved();
-          var n = nListVals.getSum();
-          for (var id2 in map[id1]) {
-              map[id1][id2] /= n;
-          }
+    for (var id1 in map) {
+      var v = []; for(var k in map[id1]) v.push(map[id1][k]);
+      var n = 0; for(var i=0; i < v.length; i++) n += v[i];
+      for(var id2 in map[id1]) {
+        map[id1][id2] /= n;
       }
+    }
   }
   return map;
 }

--- a/src/operators/structures/NetworkOperators.js
+++ b/src/operators/structures/NetworkOperators.js
@@ -1489,7 +1489,37 @@ NetworkOperators._jLouvain = function() {
   return core;
 };
 
-
+// derived from Graph.js inside http://www.clips.ua.ac.be/pages/pattern
+NetworkOperators.getAdjacencyMap = function(network,bDirected,bReversed,bStochastic){
+  if(network==null) return null;
+  bDirected = bDirected == null ? false : bDirected;
+  bReversed = bReversed == null ? false : bReversed;
+  bStochastic = bStochastic == null ? false : bStochastic;
+  var map = {};
+  for(var i=0; i < network.nodeList.length; i++) {
+      map[network.nodeList[i].id] = {};
+  }
+  for(i=0; i < network.relationList.length; i++) {
+      var e = network.relationList[i];
+      var id1 = e[(bReversed)?"node1":"node0"].id;
+      var id2 = e[(bReversed)?"node0":"node1"].id;
+      map[id1][id2] = 1.0 - e.weight*0.5;
+      if (!bDirected) { 
+          map[id2][id1] = map[id1][id2];
+      }
+  }
+  if(bStochastic) {
+      for (var id1 in map) {
+          // var n = sum(values(map[id1]));
+          var nListVals = List.fromArray(map[id1]).getImproved();
+          var n = nListVals.getSum();
+          for (var id2 in map[id1]) {
+              map[id1][id2] /= n;
+          }
+      }
+  }
+  return map;
+}
 
 /**
  * @todo write docs


### PR DESCRIPTION
Two new operators NetworkOperators.addEigenvectorCentralityToNodes and NetworkOperators.addBetweennessCentralityToNodes.

This is to address issue https://github.com/moebiolabs/modular_platform/issues/124.

The code was based on Graph.js inside http://www.clips.ua.ac.be/pages/pattern which was, in turn, translated from the python in NetworkX.

Lichen project useful for testing: jeff/test/NetworkVis/Centrality