### PR TITLE
ListOperator.buildDictionaryObject improvement

### DIFF
--- a/src/operators/lists/ListOperators.js
+++ b/src/operators/lists/ListOperators.js
@@ -489,7 +489,7 @@ ListOperators.getIndexesTable = function(list){
  * tags:
  */
 ListOperators.buildDictionaryObjectForDictionary = function(dictionary){
-  if(dictionary==null || dictionary.length<2) return;
+  if(dictionary==null || dictionary.length<2 || dictionary[0] == null || dictionary[1] == null) return;
 
   var dictionaryObject = {};
 


### PR DESCRIPTION
The function don't run if the incoming Table is null or if doesn't have 2 Lists.
But doesn't check if the inner List of the Table are or not null.
This can be a huge problem in some cases.

